### PR TITLE
APL 95 Add basic AppConfig testing to SSO Sample

### DIFF
--- a/sso-sample-ios/Base.lproj/Main.storyboard
+++ b/sso-sample-ios/Base.lproj/Main.storyboard
@@ -1,9 +1,13 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -15,30 +19,30 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="You are not logged in..." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aV0-OO-RC2">
-                                <rect key="frame" x="40" y="220" width="520" height="21"/>
+                                <rect key="frame" x="36" y="253.5" width="303" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="udL-Sw-03u">
-                                <rect key="frame" x="260" y="285" width="80" height="30"/>
-                                <color key="backgroundColor" red="0.1843137255" green="0.60784313729999995" blue="0.76078431369999999" alpha="1" colorSpace="calibratedRGB"/>
+                                <rect key="frame" x="147.5" y="318.5" width="80" height="30"/>
+                                <color key="backgroundColor" red="0.1843137255" green="0.60784313729999995" blue="0.76078431369999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="80" id="4E0-mq-SsK"/>
                                 </constraints>
                                 <state key="normal" title="Log In">
-                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="loginTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Ob2-Dt-X04"/>
                                 </connections>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="udL-Sw-03u" firstAttribute="top" secondItem="aV0-OO-RC2" secondAttribute="bottom" constant="44" id="Oj3-UF-ib9"/>
                             <constraint firstItem="udL-Sw-03u" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="SaS-Bg-8eG"/>

--- a/sso-sample-ios/Base.lproj/Main.storyboard
+++ b/sso-sample-ios/Base.lproj/Main.storyboard
@@ -23,7 +23,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="You are not logged in..." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aV0-OO-RC2">
-                                <rect key="frame" x="36" y="253.5" width="303" height="21"/>
+                                <rect key="frame" x="36" y="254" width="303" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
@@ -41,12 +41,59 @@
                                     <action selector="loginTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Ob2-Dt-X04"/>
                                 </connections>
                             </button>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="INe-kM-jmB">
+                                <rect key="frame" x="117" y="428.5" width="140" height="158.5"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2g-Ut-uWZ">
+                                        <rect key="frame" x="0.0" y="0.0" width="140" height="30"/>
+                                        <color key="backgroundColor" red="0.1843137255" green="0.60784313729999995" blue="0.76078431369999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="140" id="lY3-3t-2mX"/>
+                                        </constraints>
+                                        <state key="normal" title="Set AppConfig">
+                                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="didPressSet:" destination="BYZ-38-t0r" eventType="touchUpInside" id="39m-Eg-xfH"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HV6-72-0et">
+                                        <rect key="frame" x="0.0" y="64.5" width="140" height="30"/>
+                                        <color key="backgroundColor" red="0.1843137255" green="0.60784313729999995" blue="0.76078431369999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="140" id="Gex-pf-qFz"/>
+                                        </constraints>
+                                        <state key="normal" title="Clear AppConfig">
+                                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="didPressClear:" destination="BYZ-38-t0r" eventType="touchUpInside" id="YGr-uQ-3Iu"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JBF-La-omQ">
+                                        <rect key="frame" x="0.0" y="128.5" width="140" height="30"/>
+                                        <color key="backgroundColor" red="0.1843137255" green="0.60784313729999995" blue="0.76078431369999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="140" id="mS1-ra-luG"/>
+                                        </constraints>
+                                        <state key="normal" title="View AppConfig">
+                                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="didPressView:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Red-em-6od"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="udL-Sw-03u" firstAttribute="top" secondItem="aV0-OO-RC2" secondAttribute="bottom" constant="44" id="Oj3-UF-ib9"/>
                             <constraint firstItem="udL-Sw-03u" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="SaS-Bg-8eG"/>
+                            <constraint firstItem="INe-kM-jmB" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Twf-Tj-YRK"/>
                             <constraint firstItem="aV0-OO-RC2" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="dLv-EI-hXW"/>
+                            <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="INe-kM-jmB" secondAttribute="bottom" constant="80" id="k4p-FR-np7"/>
+                            <constraint firstItem="INe-kM-jmB" firstAttribute="top" secondItem="udL-Sw-03u" secondAttribute="bottom" constant="80" id="kxU-Le-CY0"/>
                             <constraint firstItem="udL-Sw-03u" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="nbm-ql-par"/>
                             <constraint firstItem="aV0-OO-RC2" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" constant="20" id="r2n-f3-AwD"/>
                             <constraint firstAttribute="trailingMargin" secondItem="aV0-OO-RC2" secondAttribute="trailing" constant="20" id="zMl-Wo-lme"/>

--- a/sso-sample-ios/ViewController.swift
+++ b/sso-sample-ios/ViewController.swift
@@ -73,6 +73,15 @@ class ViewController: UIViewController, ViewControllerDelegate {
         }
     }
     
+    @IBAction func didPressSet(_ sender: AnyObject) {
+    }
+    
+    @IBAction func didPressClear(_ sender: AnyObject) {
+    }
+    
+    @IBAction func didPressView(_ sender: AnyObject) {
+    }
+    
     // create the AppAuth request flow and present it to the user
     
     func login() {

--- a/sso-sample-ios/ViewController.swift
+++ b/sso-sample-ios/ViewController.swift
@@ -74,12 +74,52 @@ class ViewController: UIViewController, ViewControllerDelegate {
     }
     
     @IBAction func didPressSet(_ sender: AnyObject) {
+        
+        //
+        let configuration = [
+            "test_value":"foo"
+        ]
+        
+        UserDefaults.standard.set(configuration, forKey: "com.apple.configuration.managed")
+        UserDefaults.standard.synchronize()
+        
+        let viewController = UIAlertController(title: "Configuration has been set", message: nil, preferredStyle: .alert)
+        
+        viewController.addAction(UIAlertAction(title: "Dismiss", style: .default, handler: { (action: UIAlertAction) in
+            
+        }))
+        
+        present(viewController, animated: true, completion: nil)
     }
     
     @IBAction func didPressClear(_ sender: AnyObject) {
+        UserDefaults.standard.removeObject(forKey: "com.apple.configuration.managed")
+        UserDefaults.standard.synchronize()
+        
+        let viewController = UIAlertController(title: "Configuration has been cleared", message: nil, preferredStyle: .alert)
+        
+        viewController.addAction(UIAlertAction(title: "Dismiss", style: .default, handler: { (action: UIAlertAction) in
+            
+        }))
+        
+        present(viewController, animated: true, completion: nil)
     }
     
     @IBAction func didPressView(_ sender: AnyObject) {
+        var managedConfiguration: String? = nil
+        if let configuration = UserDefaults.standard.value(forKey: "com.apple.configuration.managed") as? Dictionary<String, AnyObject> {
+            managedConfiguration = configuration.description
+        } else {
+            managedConfiguration = "Empty"
+        }
+        
+        let viewController = UIAlertController(title: "com.apple.configuration.managed", message: managedConfiguration, preferredStyle: .alert)
+        
+        viewController.addAction(UIAlertAction(title: "Dismiss", style: .default, handler: { (action: UIAlertAction) in
+            
+        }))
+        
+        present(viewController, animated: true, completion: nil)
     }
     
     // create the AppAuth request flow and present it to the user


### PR DESCRIPTION
![simulator screen shot jan 13 2017 2 07 50 pm](https://cloud.githubusercontent.com/assets/3508548/21946920/c337e82e-d99f-11e6-8228-a6a3ca90ba0c.png)

As an ISV developer, I can see how to test if my AppConfig values are working properly by seeing an example in the SSO Sample application, so that without enrolled devices or an MDM I know if my AppConfig authentication implementation will work correctly with Harmony.

This provides a simple way that a developer can test the iOS-only part of their AppConfig implementation until a complete end-to-end test can be performed.

Given the SSO Sample App, add buttons to the UI that will:
1) Clear the AppConfig parameters from NSUserDefaults 
2) Set the sample AppConfig parameters to the NSUserDefaults
3) Check the NSUserDefaults and display the AppConfig parameters stored there